### PR TITLE
requirements.txt: remove pinned GDAL version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 grass-gis-helpers>=1.3.0
-gdal==3.8.5
+gdal
 remotezip
 wget
 psutil


### PR DESCRIPTION
Attempt to avoid pinned GDAL version (originally only needed for GitHub pages docker image)