### PR TITLE
Fix resamp overwrite of VRTs

### DIFF
--- a/r.dsm.import.bb/r.dsm.import.bb.py
+++ b/r.dsm.import.bb/r.dsm.import.bb.py
@@ -166,8 +166,10 @@ def main():
     if not native_res:
         grass.message(_("Resampling / interpolating data..."))
         grass.run_command("g.region", raster=output, res=ns_res, flags="a")
-        adjust_raster_resolution(output, output, ns_res)
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
         rm_rasters.extend(all_dsms)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DSM raster map <{output}> is created."))
 

--- a/r.dsm.import.he/r.dsm.import.he.py
+++ b/r.dsm.import.he/r.dsm.import.he.py
@@ -178,7 +178,9 @@ def main():
     if not native_res:
         grass.run_command("g.region", raster=output, res=ns_res)
         grass.message(_("Resampling / interpolating data..."))
-        adjust_raster_resolution(output, output, ns_res)
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DSM raster map <{output}> is created."))
 

--- a/r.dsm.import.hh/r.dsm.import.hh.py
+++ b/r.dsm.import.hh/r.dsm.import.hh.py
@@ -191,7 +191,9 @@ def main():
     if not native_res:
         grass.run_command("g.region", raster=output, res=ns_res)
         grass.message(_("Resampling / interpolating data..."))
-        adjust_raster_resolution(output, output, ns_res)
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DSM raster map <{output}> is created."))
 

--- a/r.dsm.import.ni/r.dsm.import.ni.py
+++ b/r.dsm.import.ni/r.dsm.import.ni.py
@@ -182,7 +182,9 @@ def main():
     if not native_res:
         grass.run_command("g.region", raster=output, res=ns_res)
         grass.message(_("Resampling / interpolating data..."))
-        adjust_raster_resolution(output, output, ns_res)
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DSM raster map <{output}> is created."))
 

--- a/r.dsm.import.sn/r.dsm.import.sn.py
+++ b/r.dsm.import.sn/r.dsm.import.sn.py
@@ -165,7 +165,9 @@ def main():
     if not native_res:
         grass.run_command("g.region", raster=output, res=ns_res)
         grass.message(_("Resampling / interpolating data..."))
-        adjust_raster_resolution(output, output, ns_res)
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DSM raster map <{output}> is created."))
 

--- a/r.dsm.import.th/r.dsm.import.th.py
+++ b/r.dsm.import.th/r.dsm.import.th.py
@@ -174,7 +174,9 @@ def main():
     if not native_res:
         grass.run_command("g.region", raster=output, res=ns_res)
         grass.message(_("Resampling / interpolating data..."))
-        adjust_raster_resolution(output, output, ns_res)
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DSM raster map <{output}> is created."))
 

--- a/r.dtm.import.he/r.dtm.import.he.py
+++ b/r.dtm.import.he/r.dtm.import.he.py
@@ -177,7 +177,9 @@ def main():
     if not native_res:
         grass.run_command("g.region", raster=output, res=ns_res)
         grass.message(_("Resampling / interpolating data..."))
-        adjust_raster_resolution(output, output, ns_res)
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DTM raster map <{output}> is created."))
 

--- a/r.dtm.import.hh/r.dtm.import.hh.py
+++ b/r.dtm.import.hh/r.dtm.import.hh.py
@@ -188,7 +188,9 @@ def main():
     if not native_res:
         grass.run_command("g.region", raster=output, res=ns_res)
         grass.message(_("Resampling / interpolating data..."))
-        adjust_raster_resolution(output, output, ns_res)
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DTM raster map <{output}> is created."))
 

--- a/r.dtm.import.ni/r.dtm.import.ni.py
+++ b/r.dtm.import.ni/r.dtm.import.ni.py
@@ -182,7 +182,9 @@ def main():
     if not native_res:
         grass.run_command("g.region", raster=output, res=ns_res)
         grass.message(_("Resampling / interpolating data..."))
-        adjust_raster_resolution(output, output, ns_res)
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DTM raster map <{output}> is created."))
 

--- a/r.dtm.import.sn/r.dtm.import.sn.py
+++ b/r.dtm.import.sn/r.dtm.import.sn.py
@@ -175,7 +175,9 @@ def main():
     if not native_res:
         grass.run_command("g.region", raster=output, res=ns_res)
         grass.message(_("Resampling / interpolating data..."))
-        adjust_raster_resolution(output, output, ns_res)
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DTM raster map <{output}> is created."))
 

--- a/r.dtm.import.th/r.dtm.import.th.py
+++ b/r.dtm.import.th/r.dtm.import.th.py
@@ -176,7 +176,9 @@ def main():
     if not native_res:
         grass.run_command("g.region", raster=output, res=ns_res)
         grass.message(_("Resampling / interpolating data..."))
-        adjust_raster_resolution(output, output, ns_res)
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DTM raster map <{output}> is created."))
 

--- a/r.dtm.import/r.dtm.import.py
+++ b/r.dtm.import/r.dtm.import.py
@@ -239,7 +239,9 @@ def main():
     if not native_res:
         grass.run_command("g.region", raster=output, res=ns_res)
         grass.message(_("Resampling / interpolating data..."))
-        adjust_raster_resolution(output, output, ns_res)
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DTM raster map <{output}> is created."))
 

--- a/r.ndsm.import.nw/r.ndsm.import.nw.py
+++ b/r.ndsm.import.nw/r.ndsm.import.nw.py
@@ -166,6 +166,7 @@ def main():
         grass.run_command("g.region", raster=vrt, res=ns_res, flags="a")
         adjust_raster_resolution(vrt, output, ns_res)
         rm_rasters.extend(all_ndsms)
+        rm_rasters.append(f"{output}_tmp")
     else:
         # create VRT
         create_vrt(all_ndsms, output)

--- a/r.ndsm.import.nw/r.ndsm.import.nw.py
+++ b/r.ndsm.import.nw/r.ndsm.import.nw.py
@@ -166,7 +166,6 @@ def main():
         grass.run_command("g.region", raster=vrt, res=ns_res, flags="a")
         adjust_raster_resolution(vrt, output, ns_res)
         rm_rasters.extend(all_ndsms)
-        rm_rasters.append(f"{output}_tmp")
     else:
         # create VRT
         create_vrt(all_ndsms, output)


### PR DESCRIPTION
If VRT overwritten, some files remain, which lead to errors if VRT-input maps do not exist.
Thus don't overwrite input, if input is VRT.