### PR TITLE
Various cleanup

### DIFF
--- a/lib_dem/r_dem_import_lib.py
+++ b/lib_dem/r_dem_import_lib.py
@@ -15,11 +15,6 @@ import os
 from time import sleep
 import grass.script as grass
 
-from grass_gis_helpers.data_import import (
-    import_local_raster_data,
-    import_local_xyz_files,
-)
-
 from grass_gis_helpers.general import set_nprocs
 
 OPEN_DATA_AVAILABILITY = {
@@ -285,66 +280,27 @@ def import_dem_from_wms(
             sleep(10)
 
 
-def import_local_data(
-        aoi,
-        out,
-        local_data_dir,
-        fs,
-        all_dems,
-        rm_rasters,
-        raster_type,
-        native_res_flag=None,
-    ):
-    """Import local DEM raster data
+def xyz_laz_clip_region_aoi(xyz_raster, output, aoi=None, region=None):
+    """Clip imported xyz/laz-file to region/aoi
 
+    r.in.pdal/r.in.xyz can not import only part of region/aoi.
+    Thus clip in a follow up step
     Args:
-        aoi (str): Vector map with area of interest
-        out (str): Base output name
-        local_data_dir (str): Path to local data directory with federal state
-                              subfolders
-        fs (str): the abbrivation of the federal state
-        all_dems (list): empty list where the imported DEM rasters
-                         will be appended
-        rm_rasters (list): List of rasters for cleanup, will be appended
-        raster_type (string): Raster files type. Either raster or xyz
-        native_res_flag (bool): True if native data resolution should be used
-                                (only used for raster import)
+        xyz_raster (str): Imported xyz/laz-file
+        output (str): Clipped output raster map
+        aoi (str): AOI if given
+        region (str): Region (if no AOI given)
 
-    """
-    if raster_type == "raster":
-        imported_local_data = import_local_raster_data(
-            aoi,
-            f"{out}_{fs}",
-            os.path.join(local_data_dir, fs),
-            native_res_flag,
-            all_dems,
-            rm_rasters,
-            band_dict=None,
-        )
-    elif raster_type == "xyz":
-        if native_res_flag == None:
-            grass.warning(_(
-                "Note, that 'native_res_flag' will be ignored"
-                "for local data import of xyz files."
-            ))
-        imported_local_data = import_local_xyz_files(
-                aoi,
-                f"{out}_{fs}",
-                os.path.join(local_data_dir, fs),
-                all_dems,
-            )
+    """    
+    if aoi:
+        grass.run_command("g.region", vector=aoi, align=xyz_raster)
     else:
-        grass.fatal(_(
-            f"Invalid raster_type for local data import: '{raster_type}'."
-            "Valid ones are 'raster' or 'xyz'."))
-
-    if not imported_local_data and fs in ["BW"]:
-        grass.fatal(_("Local data does not overlap with aoi."))
-    elif not imported_local_data:
-        grass.message(
-            _(
-                "Local data does not overlap with aoi. Data will be downloaded"
-                " from Open Data portal."
-            )
-        )
-    return imported_local_data
+        grass.run_command("g.region", region=region, align=xyz_raster)
+    grass.run_command(
+        "r.mapcalc", expression="MASK = 1", overwrite=True, quiet=True
+    )
+    grass.run_command(
+        "r.mapcalc",
+        expression=f"{output} = {xyz_raster}",
+        quiet=True,
+    )

--- a/lib_dem/r_dem_import_lib.py
+++ b/lib_dem/r_dem_import_lib.py
@@ -297,9 +297,6 @@ def xyz_laz_clip_region_aoi(xyz_raster, output, aoi=None, region=None):
     else:
         grass.run_command("g.region", region=region, align=xyz_raster)
     grass.run_command(
-        "r.mapcalc", expression="MASK = 1", overwrite=True, quiet=True
-    )
-    grass.run_command(
         "r.mapcalc",
         expression=f"{output} = {xyz_raster}",
         quiet=True,

--- a/lib_dem/r_dem_import_lib.py
+++ b/lib_dem/r_dem_import_lib.py
@@ -15,6 +15,11 @@ import os
 from time import sleep
 import grass.script as grass
 
+from grass_gis_helpers.data_import import (
+    import_local_raster_data,
+    import_local_xyz_files,
+)
+
 from grass_gis_helpers.general import set_nprocs
 
 OPEN_DATA_AVAILABILITY = {
@@ -278,3 +283,68 @@ def import_dem_from_wms(
             if count > retries:
                 grass.fatal(f"Download of {tile_url} not working.")
             sleep(10)
+
+
+def import_local_data(
+        aoi,
+        out,
+        local_data_dir,
+        fs,
+        all_dems,
+        rm_rasters,
+        raster_type,
+        native_res_flag=None,
+    ):
+    """Import local DEM raster data
+
+    Args:
+        aoi (str): Vector map with area of interest
+        out (str): Base output name
+        local_data_dir (str): Path to local data directory with federal state
+                              subfolders
+        fs (str): the abbrivation of the federal state
+        all_dems (list): empty list where the imported DEM rasters
+                         will be appended
+        rm_rasters (list): List of rasters for cleanup, will be appended
+        raster_type (string): Raster files type. Either raster or xyz
+        native_res_flag (bool): True if native data resolution should be used
+                                (only used for raster import)
+
+    """
+    if raster_type == "raster":
+        imported_local_data = import_local_raster_data(
+            aoi,
+            f"{out}_{fs}",
+            os.path.join(local_data_dir, fs),
+            native_res_flag,
+            all_dems,
+            rm_rasters,
+            band_dict=None,
+        )
+    elif raster_type == "xyz":
+        if native_res_flag == None:
+            grass.warning(_(
+                "Note, that 'native_res_flag' will be ignored"
+                "for local data import of xyz files."
+            ))
+        imported_local_data = import_local_xyz_files(
+                aoi,
+                f"{out}_{fs}",
+                os.path.join(local_data_dir, fs),
+                all_dems,
+            )
+    else:
+        grass.fatal(_(
+            f"Invalid raster_type for local data import: '{raster_type}'."
+            "Valid ones are 'raster' or 'xyz'."))
+
+    if not imported_local_data and fs in ["BW"]:
+        grass.fatal(_("Local data does not overlap with aoi."))
+    elif not imported_local_data:
+        grass.message(
+            _(
+                "Local data does not overlap with aoi. Data will be downloaded"
+                " from Open Data portal."
+            )
+        )
+    return imported_local_data

--- a/lib_dem/r_dem_import_lib.py
+++ b/lib_dem/r_dem_import_lib.py
@@ -294,8 +294,10 @@ def xyz_laz_clip_region_aoi(xyz_raster, output, aoi=None, region=None):
     """    
     if aoi:
         grass.run_command("g.region", vector=aoi, align=xyz_raster)
-    else:
+    elif region:
         grass.run_command("g.region", region=region, align=xyz_raster)
+    else:
+         grass.fatal("Neither 'region' nor 'aoi' is set, but one of them is required")
     grass.run_command(
         "r.mapcalc",
         expression=f"{output} = {xyz_raster}",

--- a/r.dsm.import.hb/r.dsm.import.hb.py
+++ b/r.dsm.import.hb/r.dsm.import.hb.py
@@ -72,7 +72,8 @@
 import atexit
 import os
 import pathlib
-
+import sys
+from grass.pygrass.utils import get_lib_path
 import grass.script as grass
 from remotezip import RemoteZip
 
@@ -87,6 +88,11 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
 )
 from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
 
+# import module library
+path = get_lib_path(modname="r.dem.import")
+if path is None:
+    grass.fatal("Unable to find the dem library directory.")
+sys.path.append(path)
 try:
     from r_dem_import_lib import xyz_laz_clip_region_aoi
 except Exception as imp_err:

--- a/r.dsm.import.hb/r.dsm.import.hb.py
+++ b/r.dsm.import.hb/r.dsm.import.hb.py
@@ -87,6 +87,11 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
 )
 from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
 
+try:
+    from r_dem_import_lib import xyz_laz_clip_region_aoi
+except Exception as imp_err:
+    grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
+
 # set variables
 TINDEX = (
     "https://github.com/mundialis/tile-indices/raw/main/DSM/HB/"
@@ -191,21 +196,13 @@ def main():
     tmp_out = f"tmp_{output}_{ID}"
     rm_rasters.append(tmp_out)
     rm_rasters.extend(all_dsms)
-    create_vrt(all_dsms, tmp_out)
+    create_vrt(all_dsms, tmp_out, copy_raster_maps=False)
 
-    # clip to region / aoi
+    # clip xyz-file to region /aoi
     if aoi:
-        grass.run_command("g.region", vector=aoi, align=tmp_out)
+        xyz_laz_clip_region_aoi(tmp_out, output, aoi=aoi)
     else:
-        grass.run_command("g.region", region=ORIG_REGION, align=tmp_out)
-    grass.run_command(
-        "r.mapcalc", expression="MASK = 1", overwrite=True, quiet=True
-    )
-    grass.run_command(
-        "r.mapcalc",
-        expression=f"{output} = {tmp_out}",
-        quiet=True,
-    )
+        xyz_laz_clip_region_aoi(tmp_out, output, region=ORIG_REGION)
 
     # resample/interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)

--- a/r.dsm.import.he/r.dsm.import.he.py
+++ b/r.dsm.import.he/r.dsm.import.he.py
@@ -83,7 +83,11 @@ from grass_gis_helpers.data_import import (
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
-from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
+from grass_gis_helpers.raster import (
+    adjust_raster_resolution,
+    create_vrt,
+    vrt_to_raster,
+)
 
 # set global variables
 TINDEX = (
@@ -176,18 +180,21 @@ def main():
                 sleep(10)
         all_dsms.append(dsm_name)
 
-    # create VRT
-    create_vrt(all_dsms, output)
+    # Create VRT of tiles
+    # (dont copy raster maps -> create real raster in the next steps)
+    vrt = f"vrt_dsm_{output}_{ID}"
+    rm_rasters.append(vrt)
+    rm_rasters.extend(all_dsms)
+    create_vrt(all_dsms, vrt, copy_raster_maps=False)
 
     # resample / interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)
     # check resolution and resample / interpolate data if needed
     if not native_res:
+        grass.message(_("Resampling / interpolating data..."))
         if alignment_raster:
             # set extent from imported data, and align with alignment raster
-            grass.run_command(
-                "g.region", raster=output, align=alignment_raster
-            )
+            grass.run_command("g.region", raster=vrt, align=alignment_raster)
             ns_res = float(
                 grass.parse_command("r.info", map=alignment_raster, flags="g")[
                     "nsres"
@@ -197,12 +204,12 @@ def main():
             # if no alignemnt raster is given,
             # use extent of imported data and
             # set and align with current region resolution
-            grass.run_command("g.region", raster=output)
+            grass.run_command("g.region", raster=vrt)
             grass.run_command("g.region", res=ns_res, flags="a")
-        grass.message(_("Resampling / interpolating data..."))
-        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
-        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
-        rm_rasters.append(f"{output}_tmp")
+        adjust_raster_resolution(vrt, output, ns_res)
+    else:
+        # Note: Want real raster/no VRT as output
+        vrt_to_raster(vrt, output)
 
     grass.message(_(f"DSM raster map <{output}> is created."))
 

--- a/r.dsm.import.ni/r.dsm.import.ni.py
+++ b/r.dsm.import.ni/r.dsm.import.ni.py
@@ -80,7 +80,12 @@ from grass_gis_helpers.data_import import (
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
-from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
+from grass_gis_helpers.raster import (
+    adjust_raster_resolution,
+    create_vrt,
+    vrt_to_raster,
+)
+
 
 # set constant variables
 TINDEX = (
@@ -164,35 +169,21 @@ def main():
         grass.run_command("r.import", **import_kwargs)
         all_dsms.append(dsm_name)
 
-    # create VRT
-    tmp_out = f"tmp_{output}_{ID}"
-    rm_rasters.append(tmp_out)
+    # Create VRT of tiles
+    # (dont copy raster maps -> create real raster in the next steps)
+    vrt = f"vrt_dsm_{output}_{ID}"
+    rm_rasters.append(vrt)
     rm_rasters.extend(all_dsms)
-    create_vrt(all_dsms, tmp_out)
-
-    # clip to region / aoi
-    if aoi:
-        grass.run_command("g.region", vector=aoi, align=tmp_out)
-    else:
-        grass.run_command("g.region", region=ORIG_REGION, align=tmp_out)
-    grass.run_command(
-        "r.mapcalc", expression="MASK = 1", overwrite=True, quiet=True
-    )
-    grass.run_command(
-        "r.mapcalc",
-        expression=f"{output} = {tmp_out}",
-        quiet=True,
-    )
+    create_vrt(all_dsms, vrt, copy_raster_maps=False)
 
     # resample / interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)
     # check resolution and resample / interpolate data if needed
     if not native_res:
+        grass.message(_("Resampling / interpolating data..."))
         if alignment_raster:
             # set extent from imported data, and align with alignment raster
-            grass.run_command(
-                "g.region", raster=output, align=alignment_raster
-            )
+            grass.run_command("g.region", raster=vrt, align=alignment_raster)
             ns_res = float(
                 grass.parse_command("r.info", map=alignment_raster, flags="g")[
                     "nsres"
@@ -204,10 +195,10 @@ def main():
             # set and align with current region resolution
             grass.run_command("g.region", raster=output)
             grass.run_command("g.region", res=ns_res, flags="a")
-        grass.message(_("Resampling / interpolating data..."))
-        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
-        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
-        rm_rasters.append(f"{output}_tmp")
+        adjust_raster_resolution(vrt, output, ns_res)
+    else:
+        # Note: Want real raster/no VRT as output
+        vrt_to_raster(vrt, output)
 
     grass.message(_(f"DSM raster map <{output}> is created."))
 

--- a/r.dsm.import.sn/r.dsm.import.sn.py
+++ b/r.dsm.import.sn/r.dsm.import.sn.py
@@ -80,7 +80,12 @@ from grass_gis_helpers.data_import import (
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
-from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
+from grass_gis_helpers.raster import (
+    adjust_raster_resolution,
+    create_vrt,
+    vrt_to_raster,
+)
+
 
 os.environ["CPL_VSIL_CURL_USE_HEAD"] = "NO"
 
@@ -165,18 +170,21 @@ def main():
         grass.run_command("r.import", **import_kwargs)
         all_dsms.append(dsm_name)
 
-    # create VRT
-    create_vrt(all_dsms, output)
+    # Create VRT of tiles
+    # (dont copy raster maps -> create real raster in the next steps)
+    vrt = f"vrt_dsm_{output}_{ID}"
+    rm_rasters.append(vrt)
+    rm_rasters.extend(all_dsms)
+    create_vrt(all_dsms, vrt, copy_raster_maps=False)
 
     # resample / interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)
     # check resolution and resample / interpolate data if needed
     if not native_res:
+        grass.message(_("Resampling / interpolating data..."))
         if alignment_raster:
             # set extent from imported data, and align with alignment raster
-            grass.run_command(
-                "g.region", raster=output, align=alignment_raster
-            )
+            grass.run_command("g.region", raster=vrt, align=alignment_raster)
             ns_res = float(
                 grass.parse_command("r.info", map=alignment_raster, flags="g")[
                     "nsres"
@@ -186,12 +194,12 @@ def main():
             # if no alignemnt raster is given,
             # use extent of imported data and
             # set and align with current region resolution
-            grass.run_command("g.region", raster=output)
+            grass.run_command("g.region", raster=vrt)
             grass.run_command("g.region", res=ns_res, flags="a")
-        grass.message(_("Resampling / interpolating data..."))
-        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
-        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
-        rm_rasters.append(f"{output}_tmp")
+        adjust_raster_resolution(vrt, output, ns_res)
+    else:
+        # Note: Want real raster/no VRT as output
+        vrt_to_raster(vrt, output)
 
     grass.message(_(f"DSM raster map <{output}> is created."))
 

--- a/r.dsm.import.th/r.dsm.import.th.py
+++ b/r.dsm.import.th/r.dsm.import.th.py
@@ -83,7 +83,12 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
     download_data_using_threadpool,
     extract_compressed_files,
 )
-from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
+from grass_gis_helpers.raster import (
+    adjust_raster_resolution,
+    create_vrt,
+    vrt_to_raster,
+)
+
 
 # set constant variables
 TINDEX = (
@@ -172,18 +177,21 @@ def main():
         import_single_local_xyz_file(xyz_file, dsm_name)
         all_dsms.append(dsm_name)
 
-    # create VRT
-    create_vrt(all_dsms, output)
+    # Create VRT of tiles
+    # (dont copy raster maps -> create real raster in the next steps)
+    vrt = f"vrt_dsm_{output}_{ID}"
+    rm_rasters.append(vrt)
+    rm_rasters.extend(all_dsms)
+    create_vrt(all_dsms, vrt, copy_raster_maps=False)
 
     # resample / interpolate whole VRT (because interpolating single files lead
     # to emplty rows and columns)
     # check resolution and resample / interpolate data if needed
     if not native_res:
+        grass.message(_("Resampling / interpolating data..."))
         if alignment_raster:
             # set extent from imported data, and align with alignment raster
-            grass.run_command(
-                "g.region", raster=output, align=alignment_raster
-            )
+            grass.run_command("g.region", raster=vrt, align=alignment_raster)
             ns_res = float(
                 grass.parse_command("r.info", map=alignment_raster, flags="g")[
                     "nsres"
@@ -193,12 +201,12 @@ def main():
             # if no alignemnt raster is given,
             # use extent of imported data and
             # set and align with current region resolution
-            grass.run_command("g.region", raster=output)
+            grass.run_command("g.region", raster=vrt)
             grass.run_command("g.region", res=ns_res, flags="a")
-        grass.message(_("Resampling / interpolating data..."))
-        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
-        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
-        rm_rasters.append(f"{output}_tmp")
+        adjust_raster_resolution(vrt, output, ns_res)
+    else:
+        # Note: Want real raster/no VRT as output
+        vrt_to_raster(vrt, output)
 
     grass.message(_(f"DSM raster map <{output}> is created."))
 

--- a/r.dsm.import/r.dsm.import.py
+++ b/r.dsm.import/r.dsm.import.py
@@ -106,7 +106,6 @@ from grass.pygrass.utils import get_lib_path
 import grass.script as grass
 
 from grass_gis_helpers.cleanup import general_cleanup
-from grass_gis_helpers.data_import import import_local_raster_data
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
@@ -126,7 +125,10 @@ if path is None:
     grass.fatal("Unable to find the dem library directory.")
 sys.path.append(path)
 try:
-    from r_dem_import_lib import OPEN_DATA_AVAILABILITY
+    from r_dem_import_lib import (
+        OPEN_DATA_AVAILABILITY,
+        import_local_data,
+    )
     from r_dem_import_metadata_lib import get_download_urls_and_names
 except Exception as imp_err:
     grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
@@ -147,42 +149,6 @@ def cleanup():
         orig_region=ORIG_REGION,
         rm_rasters=rm_rasters,
     )
-
-
-def import_local_data(aoi, out, local_data_dir, fs, all_dsms, native_res_flag):
-    """Import local DSM data
-
-    Args:
-        aoi (str): Vector map with area of interest
-        out (str): Base output name
-        local_data_dir (str): Path to local data directory with federal state
-                              subfolders
-        fs (str): the abbrivation of the federal state
-        all_dsms (list): empty list where the imported DSM rasters
-                         will be appended
-        native_res_flag (bool): True if native data resolution should be used
-
-    """
-    imported_local_data = import_local_raster_data(
-        aoi,
-        f"{out}_{fs}",
-        os.path.join(local_data_dir, fs),
-        native_res_flag,
-        all_dsms,
-        rm_rasters,
-        band_dict=None,
-    )
-
-    if not imported_local_data and fs in ["BW"]:
-        grass.fatal(_("Local data does not overlap with aoi."))
-    elif not imported_local_data:
-        grass.message(
-            _(
-                "Local data does not overlap with aoi. Data will be downloaded"
-                " from Open Data portal."
-            )
-        )
-    return imported_local_data
 
 
 def get_addon_name(fs):
@@ -226,7 +192,14 @@ def main():
         imported_local_data = False
         if fs in local_fs_list:
             imported_local_data = import_local_data(
-                aoi, output, local_data_dir, fs, all_dsms, native_res
+                aoi,
+                output,
+                local_data_dir,
+                fs,
+                all_dsms,
+                rm_rasters,
+                "raster",
+                native_res,
             )
             if imported_local_data:
                 fs_dem_list = [f"{output}_{fs}"]

--- a/r.dsm.import/r.dsm.import.py
+++ b/r.dsm.import/r.dsm.import.py
@@ -106,6 +106,7 @@ from grass.pygrass.utils import get_lib_path
 import grass.script as grass
 
 from grass_gis_helpers.cleanup import general_cleanup
+from grass_gis_helpers.data_import import import_local_raster_data
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
@@ -125,10 +126,7 @@ if path is None:
     grass.fatal("Unable to find the dem library directory.")
 sys.path.append(path)
 try:
-    from r_dem_import_lib import (
-        OPEN_DATA_AVAILABILITY,
-        import_local_data,
-    )
+    from r_dem_import_lib import OPEN_DATA_AVAILABILITY
     from r_dem_import_metadata_lib import get_download_urls_and_names
 except Exception as imp_err:
     grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
@@ -149,6 +147,42 @@ def cleanup():
         orig_region=ORIG_REGION,
         rm_rasters=rm_rasters,
     )
+
+
+def import_local_data(aoi, out, local_data_dir, fs, all_dsms, native_res_flag):
+    """Import local DSM data
+
+    Args:
+        aoi (str): Vector map with area of interest
+        out (str): Base output name
+        local_data_dir (str): Path to local data directory with federal state
+                              subfolders
+        fs (str): the abbrivation of the federal state
+        all_dsms (list): empty list where the imported DSM rasters
+                         will be appended
+        native_res_flag (bool): True if native data resolution should be used
+
+    """
+    imported_local_data = import_local_raster_data(
+        aoi,
+        f"{out}_{fs}",
+        os.path.join(local_data_dir, fs),
+        native_res_flag,
+        all_dsms,
+        rm_rasters,
+        band_dict=None,
+    )
+
+    if not imported_local_data and fs in ["BW"]:
+        grass.fatal(_("Local data does not overlap with aoi."))
+    elif not imported_local_data:
+        grass.message(
+            _(
+                "Local data does not overlap with aoi. Data will be downloaded"
+                " from Open Data portal."
+            )
+        )
+    return imported_local_data
 
 
 def get_addon_name(fs):
@@ -192,14 +226,7 @@ def main():
         imported_local_data = False
         if fs in local_fs_list:
             imported_local_data = import_local_data(
-                aoi,
-                output,
-                local_data_dir,
-                fs,
-                all_dsms,
-                rm_rasters,
-                "raster",
-                native_res,
+                aoi, output, local_data_dir, fs, all_dsms, native_res
             )
             if imported_local_data:
                 fs_dem_list = [f"{output}_{fs}"]
@@ -296,6 +323,8 @@ def main():
                 )
                 metadata_list.append(fs_metadata)
 
+    # Patch DSMs of different federal states
+    # (keep as VRT. Federal states DSMs itself are no VRTs)
     create_vrt(all_dsms, output)
     grass.message(_(f"DSM raster map <{output}> is created."))
 

--- a/r.dtm.import.bb/r.dtm.import.bb.py
+++ b/r.dtm.import.bb/r.dtm.import.bb.py
@@ -219,7 +219,7 @@ def main():
         data_file = os.path.join(download_dir, data_file_name)
         fix_corrupted_data(data_file)
         rm_files.append(f"{data_file}.bak")
-        import_single_local_xyz_file(data_file, dtm_name, separator="comma")
+        import_single_local_xyz_file(data_file, dtm_name, separator="space")
         all_dtms.append(dtm_name)
 
     # create VRT

--- a/r.dtm.import.hb/r.dtm.import.hb.py
+++ b/r.dtm.import.hb/r.dtm.import.hb.py
@@ -84,6 +84,11 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
 )
 from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
 
+try:
+    from r_dem_import_lib import xyz_laz_clip_region_aoi
+except Exception as imp_err:
+    grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
+
 # set variables
 TINDEX = (
     "https://github.com/mundialis/tile-indices/raw/main/DTM/HB/"
@@ -188,21 +193,13 @@ def main():
     tmp_out = f"tmp_{output}_{ID}"
     rm_rasters.append(tmp_out)
     rm_rasters.extend(all_dtms)
-    create_vrt(all_dtms, tmp_out)
+    create_vrt(all_dtms, tmp_out, copy_raster_maps=False)
 
-    # clip to region / aoi
+    # clip xyz-file to region /aoi
     if aoi:
-        grass.run_command("g.region", vector=aoi, align=tmp_out)
+        xyz_laz_clip_region_aoi(tmp_out, output, aoi=aoi)
     else:
-        grass.run_command("g.region", region=ORIG_REGION, align=tmp_out)
-    grass.run_command(
-        "r.mapcalc", expression="MASK = 1", overwrite=True, quiet=True
-    )
-    grass.run_command(
-        "r.mapcalc",
-        expression=f"{output} = {tmp_out}",
-        quiet=True,
-    )
+        xyz_laz_clip_region_aoi(tmp_out, output, region=ORIG_REGION)
 
     # resample/interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)

--- a/r.dtm.import.hb/r.dtm.import.hb.py
+++ b/r.dtm.import.hb/r.dtm.import.hb.py
@@ -69,6 +69,8 @@
 import atexit
 import os
 import pathlib
+import sys
+from grass.pygrass.utils import get_lib_path
 
 import grass.script as grass
 from remotezip import RemoteZip
@@ -84,6 +86,11 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
 )
 from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
 
+# import module library
+path = get_lib_path(modname="r.dem.import")
+if path is None:
+    grass.fatal("Unable to find the dem library directory.")
+sys.path.append(path)
 try:
     from r_dem_import_lib import xyz_laz_clip_region_aoi
 except Exception as imp_err:

--- a/r.dtm.import.he/r.dtm.import.he.py
+++ b/r.dtm.import.he/r.dtm.import.he.py
@@ -83,7 +83,12 @@ from grass_gis_helpers.data_import import (
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
-from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
+from grass_gis_helpers.raster import (
+    adjust_raster_resolution,
+    create_vrt,
+    vrt_to_raster,
+)
+
 
 # set constant variables
 TINDEX = (
@@ -175,18 +180,21 @@ def main():
                 sleep(10)
         all_dtms.append(dtm_name)
 
-    # create VRT
-    create_vrt(all_dtms, output)
+    # Create VRT of tiles
+    # (dont copy raster maps -> create real raster in the next steps)
+    vrt = f"vrt_dtm_{output}_{ID}"
+    rm_rasters.append(vrt)
+    rm_rasters.extend(all_dtms)
+    create_vrt(all_dtms, vrt, copy_raster_maps=False)
 
     # resample / interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)
     # check resolution and resample / interpolate data if needed
     if not native_res:
+        grass.message(_("Resampling / interpolating data..."))
         if alignment_raster:
             # set extent from imported data, and align with alignment raster
-            grass.run_command(
-                "g.region", raster=output, align=alignment_raster
-            )
+            grass.run_command("g.region", raster=vrt, align=alignment_raster)
             ns_res = float(
                 grass.parse_command("r.info", map=alignment_raster, flags="g")[
                     "nsres"
@@ -196,12 +204,12 @@ def main():
             # if no alignemnt raster is given,
             # use extent of imported data and
             # set and align with current region resolution
-            grass.run_command("g.region", raster=output)
+            grass.run_command("g.region", raster=vrt)
             grass.run_command("g.region", res=ns_res, flags="a")
-        grass.message(_("Resampling / interpolating data..."))
-        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
-        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
-        rm_rasters.append(f"{output}_tmp")
+        adjust_raster_resolution(vrt, output, ns_res)
+    else:
+        # Note: Want real raster/no VRT as output
+        vrt_to_raster(vrt, output)
 
     grass.message(_(f"DTM raster map <{output}> is created."))
 

--- a/r.dtm.import.hh/r.dtm.import.hh.py
+++ b/r.dtm.import.hh/r.dtm.import.hh.py
@@ -69,7 +69,8 @@
 import atexit
 import os
 import pathlib
-
+import sys
+from grass.pygrass.utils import get_lib_path
 import grass.script as grass
 from remotezip import RemoteZip
 
@@ -84,6 +85,11 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
 )
 from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
 
+# import module library
+path = get_lib_path(modname="r.dem.import")
+if path is None:
+    grass.fatal("Unable to find the dem library directory.")
+sys.path.append(path)
 try:
     from r_dem_import_lib import xyz_laz_clip_region_aoi
 except Exception as imp_err:

--- a/r.dtm.import.hh/r.dtm.import.hh.py
+++ b/r.dtm.import.hh/r.dtm.import.hh.py
@@ -84,6 +84,11 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
 )
 from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
 
+try:
+    from r_dem_import_lib import xyz_laz_clip_region_aoi
+except Exception as imp_err:
+    grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
+
 # set constant variables
 TINDEX = (
     "https://github.com/mundialis/tile-indices/raw/main/DTM/HH/"
@@ -175,21 +180,13 @@ def main():
     tmp_out = f"tmp_{output}_{ID}"
     rm_rasters.append(tmp_out)
     rm_rasters.extend(all_dtms)
-    create_vrt(all_dtms, tmp_out)
+    create_vrt(all_dtms, tmp_out, copy_raster_maps=False)
 
-    # clip to region / aoi
+     # clip xyz-file to region /aoi
     if aoi:
-        grass.run_command("g.region", vector=aoi, align=tmp_out)
+        xyz_laz_clip_region_aoi(tmp_out, output, aoi=aoi)
     else:
-        grass.run_command("g.region", region=ORIG_REGION, align=tmp_out)
-    grass.run_command(
-        "r.mapcalc", expression="MASK = 1", overwrite=True, quiet=True
-    )
-    grass.run_command(
-        "r.mapcalc",
-        expression=f"{output} = {tmp_out}",
-        quiet=True,
-    )
+        xyz_laz_clip_region_aoi(tmp_out, output, region=ORIG_REGION)
 
     # resample / interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)

--- a/r.dtm.import.ni/r.dtm.import.ni.py
+++ b/r.dtm.import.ni/r.dtm.import.ni.py
@@ -80,7 +80,12 @@ from grass_gis_helpers.data_import import (
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
-from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
+from grass_gis_helpers.raster import (
+    adjust_raster_resolution,
+    create_vrt,
+    vrt_to_raster,
+)
+
 
 # set constant variables
 TINDEX = (
@@ -141,7 +146,7 @@ def main():
     # get data files which overlap with aoi
     url_tiles = get_list_of_tindex_locations(tindex_vect, aoi)
 
-    # import XYZ DTM files
+    # import DTM files
     grass.message(_("Importing DTM..."))
     all_dtms = []
     if native_res:
@@ -163,35 +168,21 @@ def main():
         grass.run_command("r.import", **import_kwargs)
         all_dtms.append(dsm_name)
 
-    # create VRT
-    tmp_out = f"tmp_{output}_{ID}"
-    rm_rasters.append(tmp_out)
+    # Create VRT of tiles
+    # (dont copy raster maps -> create real raster in the next steps)
+    vrt = f"vrt_dtm_{output}_{ID}"
+    rm_rasters.append(vrt)
     rm_rasters.extend(all_dtms)
-    create_vrt(all_dtms, tmp_out)
-
-    # clip to region / aoi
-    if aoi:
-        grass.run_command("g.region", vector=aoi, align=tmp_out)
-    else:
-        grass.run_command("g.region", region=ORIG_REGION, align=tmp_out)
-    grass.run_command(
-        "r.mapcalc", expression="MASK = 1", overwrite=True, quiet=True
-    )
-    grass.run_command(
-        "r.mapcalc",
-        expression=f"{output} = {tmp_out}",
-        quiet=True,
-    )
+    create_vrt(all_dtms, vrt, copy_raster_maps=False)
 
     # resample / interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)
     # check resolution and resample / interpolate data if needed
     if not native_res:
+        grass.message(_("Resampling / interpolating data..."))
         if alignment_raster:
             # set extent from imported data, and align with alignment raster
-            grass.run_command(
-                "g.region", raster=output, align=alignment_raster
-            )
+            grass.run_command("g.region", raster=vrt, align=alignment_raster)
             ns_res = float(
                 grass.parse_command("r.info", map=alignment_raster, flags="g")[
                     "nsres"
@@ -201,12 +192,12 @@ def main():
             # if no alignemnt raster is given,
             # use extent of imported data and
             # set and align with current region resolution
-            grass.run_command("g.region", raster=output)
+            grass.run_command("g.region", raster=vrt)
             grass.run_command("g.region", res=ns_res, flags="a")
-        grass.message(_("Resampling / interpolating data..."))
-        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
-        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
-        rm_rasters.append(f"{output}_tmp")
+        adjust_raster_resolution(vrt, output, ns_res)
+    else:
+        # Note: Want real raster/no VRT as output
+        vrt_to_raster(vrt, output)
 
     grass.message(_(f"DTM raster map <{output}> is created."))
 

--- a/r.dtm.import.nw/r.dtm.import.nw.py
+++ b/r.dtm.import.nw/r.dtm.import.nw.py
@@ -79,7 +79,11 @@ from grass_gis_helpers.data_import import (
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
-from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
+from grass_gis_helpers.raster import (
+    adjust_raster_resolution,
+    create_vrt,
+    vrt_to_raster,
+)
 
 # set constant variables
 TINDEX = (
@@ -145,7 +149,7 @@ def main():
 
     # import DTM directly
     grass.message(_("Importing DTM..."))
-    all_dtm = []
+    all_dtms = []
     for url in url_tiles:
         dtm_name = os.path.splitext(os.path.basename(url))[0].replace("-", "")
         if "/vsicurl/" not in url:
@@ -158,17 +162,19 @@ def main():
             overwrite=True,
             quiet=True,
         )
-        all_dtm.append(dtm_name)
+        all_dtms.append(dtm_name)
+
+    # Create VRT of tiles
+    # (dont copy raster maps -> create real raster in the next steps)
+    vrt = f"vrt_dtm_{output}_{ID}"
+    rm_rasters.append(vrt)
+    rm_rasters.extend(all_dtms)
+    create_vrt(all_dtms, vrt, copy_raster_maps=False)
 
     # resample / interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)
     # check resolution and resample / interpolate data if needed
     if not native_res:
-        # create VRT
-        vrt = f"vrt_dtm_{ID}"
-        rm_rasters.append(vrt)
-        create_vrt(all_dtm, vrt)
-
         grass.message(_("Resampling / interpolating data..."))
         if alignment_raster:
             # set extent from imported data, and align with alignment raster
@@ -185,10 +191,9 @@ def main():
             grass.run_command("g.region", raster=vrt)
             grass.run_command("g.region", res=ns_res, flags="a")
         adjust_raster_resolution(vrt, output, ns_res)
-        rm_rasters.extend(all_dtm)
     else:
-        # create VRT
-        create_vrt(all_dtm, output)
+        # Note: Want real raster/no VRT as output
+        vrt_to_raster(vrt, output)
 
     grass.message(_(f"DTM raster map <{output}> is created."))
 

--- a/r.dtm.import.sh/r.dtm.import.sh.py
+++ b/r.dtm.import.sh/r.dtm.import.sh.py
@@ -62,6 +62,8 @@
 import atexit
 import os
 from urllib.parse import urlparse, parse_qs
+import sys
+from grass.pygrass.utils import get_lib_path
 import grass.script as grass
 import requests
 from grass_gis_helpers.cleanup import general_cleanup
@@ -73,6 +75,11 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
 )
 from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
 
+# import module library
+path = get_lib_path(modname="r.dem.import")
+if path is None:
+    grass.fatal("Unable to find the dem library directory.")
+sys.path.append(path)
 try:
     from r_dem_import_lib import xyz_laz_clip_region_aoi
 except Exception as imp_err:

--- a/r.dtm.import.sh/r.dtm.import.sh.py
+++ b/r.dtm.import.sh/r.dtm.import.sh.py
@@ -44,6 +44,13 @@
 # % description: Name for output raster map
 # %end
 
+# %option
+# % key: metadata_file
+# % type: string
+# % required: no
+# % description: Temporary file for metadata URLs
+# %end
+
 # %flag
 # % key: k
 # % label: Keep downloaded data in the download directory
@@ -61,6 +68,7 @@
 
 import atexit
 import os
+import pathlib
 from urllib.parse import urlparse, parse_qs
 import sys
 from grass.pygrass.utils import get_lib_path
@@ -69,6 +77,7 @@ import requests
 from grass_gis_helpers.cleanup import general_cleanup
 from grass_gis_helpers.data_import import (
     download_and_import_tindex,
+    get_list_of_tindex_locations,
 )
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
@@ -123,6 +132,7 @@ def main():
     aoi = options["aoi"]
     download_dir = check_download_dir(options["download_dir"])
     alignment_raster = options["alignment_raster"]
+    metadata_file = options["metadata_file"]
     output = options["output"]
     keep_data = flags["k"]
     native_res = flags["r"]
@@ -140,38 +150,13 @@ def main():
     rm_vectors.append(tindex_vect)
     download_and_import_tindex(TINDEX, tindex_vect, download_dir)
 
-    # get tiles which overlap with aoi
-    def url_tiles(tindex_vect, aoi):
-        tindex_clipped = f"clipped_tindex_vect_{grass.tempname(8)}"
-        rm_vectors.append(tindex_clipped)
-        v_clip_kwargs = {
-            "input": tindex_vect,
-            "output": tindex_clipped,
-            "flags": "",
-            "quiet": True,
-        }
-        if aoi:
-            v_clip_kwargs["clip"] = aoi
-            v_clip_kwargs["flags"] += "d"
-        else:
-            v_clip_kwargs["flags"] += "r"
-        grass.run_command("v.clip", **v_clip_kwargs)
-        tiles = [
-            val[0]
-            for val in grass.vector_db_select(
-                tindex_clipped,
-                columns="link_data",
-            )["values"].values()
-        ]
-        return tiles
-
-    # create list with tile urls
-    url_tiles_list = url_tiles(tindex_vect, aoi)
+    # get download urls which overlap with aoi
+    url_tiles = get_list_of_tindex_locations(tindex_vect, aoi)
 
     # download DTM files
     grass.message(_("Importing DTM..."))
     all_dtms = []
-    for url in url_tiles_list:
+    for url in url_tiles:
         if aoi:
             grass.run_command("g.region", vector=aoi, flags="a")
         else:
@@ -253,6 +238,15 @@ def main():
         rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"DTM raster map <{output}> is created."))
+
+    if metadata_file and url_tiles:
+        try:
+            with pathlib.Path(metadata_file).open("w", encoding="utf-8") as f:
+                for url in url_tiles:
+                    f.write(f"{url}\n")
+            grass.debug("Wrote tile URLs to tempfile")
+        except Exception as e:
+            grass.warning(f"Could not write tempfile metadata: {e}")
 
 
 if __name__ == "__main__":

--- a/r.dtm.import.sh/r.dtm.import.sh.py
+++ b/r.dtm.import.sh/r.dtm.import.sh.py
@@ -73,6 +73,11 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
 )
 from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
 
+try:
+    from r_dem_import_lib import xyz_laz_clip_region_aoi
+except Exception as imp_err:
+    grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
+
 # set variables
 TINDEX = (
     "https://github.com/mundialis/tile-indices/raw/main/DTM/SH/"
@@ -207,21 +212,13 @@ def main():
     # create VRT
     tmp_out = f"tmp_{output}_{ID}"
     rm_rasters.append(tmp_out)
-    create_vrt(all_dtms, tmp_out)
+    create_vrt(all_dtms, tmp_out, copy_raster_maps=False)
 
-    # clip to region / aoi
+    # clip xyz-file to region /aoi
     if aoi:
-        grass.run_command("g.region", vector=aoi, align=tmp_out)
+        xyz_laz_clip_region_aoi(tmp_out, output, aoi=aoi)
     else:
-        grass.run_command("g.region", region=ORIG_REGION, align=tmp_out)
-    grass.run_command(
-        "r.mapcalc", expression="MASK = 1", overwrite=True, quiet=True
-    )
-    grass.run_command(
-        "r.mapcalc",
-        expression=f"{output} = {tmp_out}",
-        quiet=True,
-    )
+        xyz_laz_clip_region_aoi(tmp_out, output, region=ORIG_REGION)
 
     # resample/interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)

--- a/r.dtm.import.sn/r.dtm.import.sn.py
+++ b/r.dtm.import.sn/r.dtm.import.sn.py
@@ -82,7 +82,12 @@ from grass_gis_helpers.data_import import (
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
-from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
+from grass_gis_helpers.raster import (
+    adjust_raster_resolution,
+    create_vrt,
+    vrt_to_raster,
+)
+
 
 os.environ["CPL_VSIL_CURL_USE_HEAD"] = "NO"
 
@@ -175,18 +180,21 @@ def main():
                 sleep(10)
         all_dtms.append(dtm_name)
 
-    # create VRT
-    create_vrt(all_dtms, output)
+    # Create VRT of tiles
+    # (dont copy raster maps -> create real raster in the next steps)
+    vrt = f"vrt_dtm_{output}_{ID}"
+    rm_rasters.append(vrt)
+    rm_rasters.extend(all_dtms)
+    create_vrt(all_dtms, vrt, copy_raster_maps=False)
 
     # resample / interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)
     # check resolution and resample / interpolate data if needed
     if not native_res:
+        grass.message(_("Resampling / interpolating data..."))
         if alignment_raster:
             # set extent from imported data, and align with alignment raster
-            grass.run_command(
-                "g.region", raster=output, align=alignment_raster
-            )
+            grass.run_command("g.region", raster=vrt, align=alignment_raster)
             ns_res = float(
                 grass.parse_command("r.info", map=alignment_raster, flags="g")[
                     "nsres"
@@ -198,10 +206,10 @@ def main():
             # set and align with current region resolution
             grass.run_command("g.region", raster=output)
             grass.run_command("g.region", res=ns_res, flags="a")
-        grass.message(_("Resampling / interpolating data..."))
-        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
-        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
-        rm_rasters.append(f"{output}_tmp")
+        adjust_raster_resolution(vrt, output, ns_res)
+    else:
+        # Note: Want real raster/no VRT as output
+        vrt_to_raster(vrt, output)
 
     grass.message(_(f"DTM raster map <{output}> is created."))
 

--- a/r.dtm.import.th/r.dtm.import.th.py
+++ b/r.dtm.import.th/r.dtm.import.th.py
@@ -87,6 +87,12 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
 )
 from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
 
+try:
+    from r_dem_import_lib import xyz_laz_clip_region_aoi
+except Exception as imp_err:
+    grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
+
+
 # set global variables
 TINDEX = (
     "https://github.com/mundialis/tile-indices/raw/main/DTM/TH/"
@@ -174,8 +180,18 @@ def main():
         import_single_local_xyz_file(xyz_file, dtm_name)
         all_dtms.append(dtm_name)
 
-    # create VRT
-    create_vrt(all_dtms, output)
+    #  create VRT
+    tmp_out = f"tmp_{output}_{ID}"
+    rm_rasters.append(tmp_out)
+    rm_rasters.extend(all_dtms)
+    create_vrt(all_dtms, tmp_out, copy_raster_maps=False)
+
+    # clip xyz-file to region /aoi
+    if aoi:
+        xyz_laz_clip_region_aoi(tmp_out, output, aoi=aoi)
+    else:
+        xyz_laz_clip_region_aoi(tmp_out, output, region=ORIG_REGION)
+
 
     # resample / interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)

--- a/r.dtm.import.th/r.dtm.import.th.py
+++ b/r.dtm.import.th/r.dtm.import.th.py
@@ -69,8 +69,10 @@
 import atexit
 import os
 import pathlib
+import sys
 
 import grass.script as grass
+from grass.pygrass.utils import get_lib_path
 
 from grass_gis_helpers.cleanup import general_cleanup
 from grass_gis_helpers.data_import import (
@@ -87,6 +89,11 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
 )
 from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
 
+# import module library
+path = get_lib_path(modname="r.dem.import")
+if path is None:
+    grass.fatal("Unable to find the dem library directory.")
+sys.path.append(path)
 try:
     from r_dem_import_lib import xyz_laz_clip_region_aoi
 except Exception as imp_err:

--- a/r.dtm.import/r.dtm.import.py
+++ b/r.dtm.import/r.dtm.import.py
@@ -105,7 +105,6 @@ import grass.script as grass
 from grass.pygrass.utils import get_lib_path
 
 from grass_gis_helpers.cleanup import general_cleanup
-from grass_gis_helpers.data_import import import_local_xyz_files
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
@@ -125,7 +124,10 @@ if path is None:
     grass.fatal("Unable to find the dem library directory.")
 sys.path.append(path)
 try:
-    from r_dem_import_lib import OPEN_DATA_AVAILABILITY
+    from r_dem_import_lib import (
+        OPEN_DATA_AVAILABILITY,
+        import_local_data,
+    )
     from r_dem_import_metadata_lib import get_download_urls_and_names
 except Exception as imp_err:
     grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
@@ -145,37 +147,6 @@ def cleanup():
         orig_region=ORIG_REGION,
         rm_rasters=rm_rasters,
     )
-
-
-def import_local_data(aoi, out, local_data_dir, fs, all_dtms):
-    """Import local DTM data
-
-    Args:
-        aoi (str): Vector map with area of interest
-        out (str): Base output name
-        local_data_dir (str): Path to local data directory with federal state
-                              subfolders
-        fs (str): the abbrivation of the federal state
-        all_dtms (list): empty list where the imported DTM rasters
-                         will be appended
-    """
-    imported_local_data = import_local_xyz_files(
-        aoi,
-        f"{out}_{fs}",
-        os.path.join(local_data_dir, fs),
-        all_dtms,
-    )
-
-    if not imported_local_data and fs in ["BW"]:
-        grass.fatal(_("Local data does not overlap with aoi."))
-    elif not imported_local_data:
-        grass.message(
-            _(
-                "Local data does not overlap with aoi. Data will be downloaded"
-                " from Open Data portal."
-            )
-        )
-    return imported_local_data
 
 
 def get_addon_name(fs):
@@ -219,7 +190,7 @@ def main():
         imported_local_data = False
         if fs in local_fs_list:
             imported_local_data = import_local_data(
-                aoi, output, local_data_dir, fs, all_dtms
+                aoi, output, local_data_dir, fs, all_dtms, rm_rasters, "xyz",
             )
             if imported_local_data:
                 fs_dem_list = [f"{output}_{fs}"]

--- a/r.dtm.import/r.dtm.import.py
+++ b/r.dtm.import/r.dtm.import.py
@@ -105,6 +105,7 @@ import grass.script as grass
 from grass.pygrass.utils import get_lib_path
 
 from grass_gis_helpers.cleanup import general_cleanup
+from grass_gis_helpers.data_import import import_local_xyz_files
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
@@ -124,10 +125,7 @@ if path is None:
     grass.fatal("Unable to find the dem library directory.")
 sys.path.append(path)
 try:
-    from r_dem_import_lib import (
-        OPEN_DATA_AVAILABILITY,
-        import_local_data,
-    )
+    from r_dem_import_lib import OPEN_DATA_AVAILABILITY
     from r_dem_import_metadata_lib import get_download_urls_and_names
 except Exception as imp_err:
     grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
@@ -147,6 +145,37 @@ def cleanup():
         orig_region=ORIG_REGION,
         rm_rasters=rm_rasters,
     )
+
+
+def import_local_data(aoi, out, local_data_dir, fs, all_dtms):
+    """Import local DTM data
+
+    Args:
+        aoi (str): Vector map with area of interest
+        out (str): Base output name
+        local_data_dir (str): Path to local data directory with federal state
+                              subfolders
+        fs (str): the abbrivation of the federal state
+        all_dtms (list): empty list where the imported DTM rasters
+                         will be appended
+    """
+    imported_local_data = import_local_xyz_files(
+        aoi,
+        f"{out}_{fs}",
+        os.path.join(local_data_dir, fs),
+        all_dtms,
+    )
+
+    if not imported_local_data and fs in ["BW"]:
+        grass.fatal(_("Local data does not overlap with aoi."))
+    elif not imported_local_data:
+        grass.message(
+            _(
+                "Local data does not overlap with aoi. Data will be downloaded"
+                " from Open Data portal."
+            )
+        )
+    return imported_local_data
 
 
 def get_addon_name(fs):
@@ -190,7 +219,7 @@ def main():
         imported_local_data = False
         if fs in local_fs_list:
             imported_local_data = import_local_data(
-                aoi, output, local_data_dir, fs, all_dtms, rm_rasters, "xyz",
+                aoi, output, local_data_dir, fs, all_dtms
             )
             if imported_local_data:
                 fs_dem_list = [f"{output}_{fs}"]
@@ -286,6 +315,8 @@ def main():
                 )
                 metadata_list.append(fs_metadata)
 
+    # Patch DTMs of different federal states
+    # (keep as VRT. Federal states DTMs itself are no VRTs)
     create_vrt(all_dtms, output)
     grass.message(_(f"DTM raster map <{output}> is created."))
 

--- a/r.idsm.import.hh/r.idsm.import.hh.py
+++ b/r.idsm.import.hh/r.idsm.import.hh.py
@@ -71,6 +71,8 @@ import os
 import pathlib
 import grass.script as grass
 from remotezip import RemoteZip
+import sys
+from grass.pygrass.utils import get_lib_path
 
 from grass_gis_helpers.cleanup import general_cleanup
 from grass_gis_helpers.data_import import (
@@ -83,6 +85,11 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
 )
 from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
 
+# import module library
+path = get_lib_path(modname="r.dem.import")
+if path is None:
+    grass.fatal("Unable to find the dem library directory.")
+sys.path.append(path)
 try:
     from r_dem_import_lib import xyz_laz_clip_region_aoi
 except Exception as imp_err:

--- a/r.idsm.import.hh/r.idsm.import.hh.py
+++ b/r.idsm.import.hh/r.idsm.import.hh.py
@@ -83,6 +83,12 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
 )
 from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
 
+try:
+    from r_dem_import_lib import xyz_laz_clip_region_aoi
+except Exception as imp_err:
+    grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
+
+
 # set constant variables
 TINDEX = (
     "https://github.com/mundialis/tile-indices/raw/main/iDSM/HH/"
@@ -176,21 +182,13 @@ def main():
     tmp_out = f"tmp_{output}_{ID}"
     rm_rasters.append(tmp_out)
     rm_rasters.extend(all_dsms)
-    create_vrt(all_dsms, tmp_out)
+    create_vrt(all_dsms, tmp_out, copy_raster_maps=False)
 
-    # clip to region / aoi
+    # clip xyz-file to region /aoi
     if aoi:
-        grass.run_command("g.region", vector=aoi, align=tmp_out)
+        xyz_laz_clip_region_aoi(tmp_out, output, aoi=aoi)
     else:
-        grass.run_command("g.region", region=ORIG_REGION, align=tmp_out)
-    grass.run_command(
-        "r.mapcalc", expression="MASK = 1", overwrite=True, quiet=True
-    )
-    grass.run_command(
-        "r.mapcalc",
-        expression=f"{output} = {tmp_out}",
-        quiet=True,
-    )
+        xyz_laz_clip_region_aoi(tmp_out, output, region=ORIG_REGION)
 
     # resample / interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)

--- a/r.idsm.import.nw/r.idsm.import.nw.py
+++ b/r.idsm.import.nw/r.idsm.import.nw.py
@@ -86,6 +86,11 @@ from grass_gis_helpers.raster import (
     vrt_to_raster,
 )
 
+try:
+    from r_dem_import_lib import xyz_laz_clip_region_aoi
+except Exception as imp_err:
+    grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
+
 
 # set constant variables
 TINDEX = (
@@ -188,19 +193,27 @@ def main():
         grass.run_command("r.in.pdal", **r_in_pdal_kwargs)
         all_idsms.append(idsm_name)
 
+    # create VRT
+    tmp_out = f"tmp_{output}_{ID}"
+    rm_rasters.append(tmp_out)
+    rm_rasters.extend(all_idsms)
+    create_vrt(all_idsms, tmp_out, copy_raster_maps=False)
+
+    # clip xyz-file to region /aoi
+    if aoi:
+        xyz_laz_clip_region_aoi(tmp_out, output, aoi=aoi)
+    else:
+        xyz_laz_clip_region_aoi(tmp_out, output, region=ORIG_REGION)
+
+
     # resample / interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)
     # check resolution and resample / interpolate data if needed
     if not native_res:
-        # create VRT
-        vrt = f"vrt_idsm_{ID}"
-        rm_rasters.append(vrt)
-        create_vrt(all_idsms, vrt)
-
         grass.message(_("Resampling / interpolating data..."))
         if alignment_raster:
             # set extent from imported data, and align with alignment raster
-            grass.run_command("g.region", raster=vrt, align=alignment_raster)
+            grass.run_command("g.region", raster=output, align=alignment_raster)
             ns_res = float(
                 grass.parse_command("r.info", map=alignment_raster, flags="g")[
                     "nsres"
@@ -210,13 +223,12 @@ def main():
             # if no alignemnt raster is given,
             # use extent of imported data and
             # set and align with current region resolution
-            grass.run_command("g.region", raster=vrt)
+            grass.run_command("g.region", raster=output)
             grass.run_command("g.region", res=ns_res, flags="a")
-        adjust_raster_resolution(vrt, output, ns_res)
-        rm_rasters.extend(all_idsms)
-    else:
-        # create VRT
-        create_vrt(all_idsms, output)
+        grass.message(_("Resampling / interpolating data..."))
+        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
+        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
+        rm_rasters.append(f"{output}_tmp")
 
     grass.message(_(f"iDSM raster map <{output}> is created."))
 

--- a/r.idsm.import.nw/r.idsm.import.nw.py
+++ b/r.idsm.import.nw/r.idsm.import.nw.py
@@ -80,7 +80,12 @@ from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
     download_data_using_threadpool,
 )
-from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
+from grass_gis_helpers.raster import (
+    adjust_raster_resolution,
+    create_vrt,
+    vrt_to_raster,
+)
+
 
 # set constant variables
 TINDEX = (

--- a/r.idsm.import.nw/r.idsm.import.nw.py
+++ b/r.idsm.import.nw/r.idsm.import.nw.py
@@ -70,6 +70,8 @@ import atexit
 import os
 import pathlib
 import grass.script as grass
+import sys
+from grass.pygrass.utils import get_lib_path
 
 from grass_gis_helpers.cleanup import general_cleanup
 from grass_gis_helpers.data_import import (
@@ -86,6 +88,11 @@ from grass_gis_helpers.raster import (
     vrt_to_raster,
 )
 
+# import module library
+path = get_lib_path(modname="r.dem.import")
+if path is None:
+    grass.fatal("Unable to find the dem library directory.")
+sys.path.append(path)
 try:
     from r_dem_import_lib import xyz_laz_clip_region_aoi
 except Exception as imp_err:

--- a/r.idsm.import.sh/r.idsm.import.sh.py
+++ b/r.idsm.import.sh/r.idsm.import.sh.py
@@ -71,7 +71,12 @@ from grass_gis_helpers.data_import import download_and_import_tindex
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
-from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
+from grass_gis_helpers.raster import (
+    adjust_raster_resolution,
+    create_vrt,
+    vrt_to_raster,
+)
+
 
 # set variables
 TINDEX = (
@@ -182,25 +187,12 @@ def main():
         )
         all_idsms.append(idsm_name)
 
-    # create VRT
-    tmp_out = f"tmp_{output}_{ID}"
-    rm_rasters.append(tmp_out)
+    # Create VRT of tiles
+    # (dont copy raster maps -> create real raster in the next steps)
+    vrt = f"vrt_idsm_{output}_{ID}"
+    rm_rasters.append(vrt)
     rm_rasters.extend(all_idsms)
-    create_vrt(all_idsms, tmp_out)
-
-    # clip to region / aoi
-    if aoi:
-        grass.run_command("g.region", vector=aoi, align=tmp_out)
-    else:
-        grass.run_command("g.region", region=ORIG_REGION, align=tmp_out)
-    grass.run_command(
-        "r.mapcalc", expression="MASK = 1", overwrite=True, quiet=True
-    )
-    grass.run_command(
-        "r.mapcalc",
-        expression=f"{output} = {tmp_out}",
-        quiet=True,
-    )
+    create_vrt(all_idsms, vrt, copy_raster_maps=False)
 
     # resample/interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)
@@ -208,9 +200,7 @@ def main():
     if not native_res:
         if alignment_raster:
             # set extent from imported data, and align with alignment raster
-            grass.run_command(
-                "g.region", raster=output, align=alignment_raster
-            )
+            grass.run_command("g.region", raster=vrt, align=alignment_raster)
             ns_res = float(
                 grass.parse_command("r.info", map=alignment_raster, flags="g")[
                     "nsres"
@@ -220,12 +210,12 @@ def main():
             # if no alignemnt raster is given,
             # use extent of imported data and
             # set and align with current region resolution
-            grass.run_command("g.region", raster=output)
+            grass.run_command("g.region", raster=vrt)
             grass.run_command("g.region", res=ns_res, flags="a")
-        grass.message(_("Resampling / interpolating data..."))
-        grass.run_command("g.rename", raster=f"{output},{output}_tmp")
-        adjust_raster_resolution(f"{output}_tmp", output, ns_res)
-        rm_rasters.append(f"{output}_tmp")
+        adjust_raster_resolution(vrt, output, ns_res)
+    else:
+        # Note: Want real raster/no VRT as output
+        vrt_to_raster(vrt, output)
 
     grass.message(_(f"iDSM raster map <{output}> is created."))
 

--- a/r.idsm.import.sh/r.idsm.import.sh.py
+++ b/r.idsm.import.sh/r.idsm.import.sh.py
@@ -46,6 +46,13 @@
 # % description: Name for output raster map
 # %end
 
+# %option
+# % key: metadata_file
+# % type: string
+# % required: no
+# % description: Temporary file for metadata URLs
+# %end
+
 # %flag
 # % key: k
 # % label: Keep downloaded data in the download directory
@@ -63,11 +70,15 @@
 
 import atexit
 import os
+import pathlib
 from urllib.parse import urlparse, parse_qs
 import grass.script as grass
 
 from grass_gis_helpers.cleanup import general_cleanup
-from grass_gis_helpers.data_import import download_and_import_tindex
+from grass_gis_helpers.data_import import (
+    download_and_import_tindex,
+    get_list_of_tindex_locations,
+)
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
@@ -116,6 +127,7 @@ def main():
     aoi = options["aoi"]
     download_dir = check_download_dir(options["download_dir"])
     alignment_raster = options["alignment_raster"]
+    metadata_file = options["metadata_file"]
     output = options["output"]
     keep_data = flags["k"]
     native_res = flags["r"]
@@ -133,42 +145,13 @@ def main():
     rm_vectors.append(tindex_vect)
     download_and_import_tindex(TINDEX, tindex_vect, download_dir)
 
-    # get tiles which overlap with aoi
-    def url_tiles(tindex_vect, aoi):
-        tindex_clipped = f"clipped_tindex_vect_{grass.tempname(8)}"
-        try:
-            v_clip_kwargs = {
-                "input": tindex_vect,
-                "output": tindex_clipped,
-                "flags": "",
-                "quiet": True,
-            }
-            if aoi:
-                v_clip_kwargs["clip"] = aoi
-                v_clip_kwargs["flags"] += "d"
-            else:
-                v_clip_kwargs["flags"] += "r"
-            grass.run_command("v.clip", **v_clip_kwargs)
-            tiles = [
-                val[0]
-                for val in grass.vector_db_select(
-                    tindex_clipped,
-                    columns="link_data",
-                )["values"].values()
-            ]
-
-            return tiles
-
-        finally:
-            rm_vectors.extend(tindex_clipped)
-
-    # create list with tile urls
-    url_tiles_list = url_tiles(tindex_vect, aoi)
+    # get download urls which overlap with aoi
+    url_tiles = get_list_of_tindex_locations(tindex_vect, aoi)
 
     # import iDSM files
     grass.message(_("Importing iDSM..."))
     all_idsms = []
-    for url in url_tiles_list:
+    for url in url_tiles:
         if aoi:
             grass.run_command("g.region", vector=aoi)
         else:
@@ -218,6 +201,15 @@ def main():
         vrt_to_raster(vrt, output)
 
     grass.message(_(f"iDSM raster map <{output}> is created."))
+
+    if metadata_file and url_tiles:
+        try:
+            with pathlib.Path(metadata_file).open("w", encoding="utf-8") as f:
+                for url in url_tiles:
+                    f.write(f"{url}\n")
+            grass.debug("Wrote tile URLs to tempfile")
+        except Exception as e:
+            grass.warning(f"Could not write tempfile metadata: {e}")
 
 
 if __name__ == "__main__":

--- a/r.idsm.import/r.idsm.import.py
+++ b/r.idsm.import/r.idsm.import.py
@@ -233,6 +233,8 @@ def main():
             )
             metadata_list.append(fs_metadata)
 
+    # Patch iDSMs of different federal states
+    # (keep as VRT. Federal states iDSMs itself are no VRTs)
     create_vrt(all_idsms, output)
     grass.message(_(f"iDSM raster map <{output}> is created."))
 

--- a/r.ndsm.import.nw/r.ndsm.import.nw.py
+++ b/r.ndsm.import.nw/r.ndsm.import.nw.py
@@ -80,7 +80,11 @@ from grass_gis_helpers.data_import import (
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
-from grass_gis_helpers.raster import adjust_raster_resolution, create_vrt
+from grass_gis_helpers.raster import (
+    adjust_raster_resolution,
+    create_vrt,
+    vrt_to_raster,
+)
 
 # set constant variables
 TINDEX = (
@@ -171,15 +175,17 @@ def main():
                 sleep(10)
         all_ndsms.append(ndsm_name)
 
+    # Create VRT of tiles
+    # (dont copy raster maps -> create real raster in the next steps)
+    vrt = f"vrt_ndsm_{output}_{ID}"
+    rm_rasters.append(vrt)
+    rm_rasters.extend(all_ndsms)
+    create_vrt(all_ndsms, vrt, copy_raster_maps=False)
+    
     # resample / interpolate whole VRT (because interpolating single files leads
     # to empty rows and columns)
     # check resolution and resample / interpolate data if needed
     if not native_res:
-        # create VRT
-        vrt = f"vrt_ndsm_{ID}"
-        rm_rasters.append(vrt)
-        create_vrt(all_ndsms, vrt)
-
         grass.message(_("Resampling / interpolating data..."))
         if alignment_raster:
             # set extent from imported data, and align with alignment raster
@@ -196,10 +202,9 @@ def main():
             grass.run_command("g.region", raster=vrt)
             grass.run_command("g.region", res=ns_res, flags="a")
         adjust_raster_resolution(vrt, output, ns_res)
-        rm_rasters.extend(all_ndsms)
     else:
-        # create VRT
-        create_vrt(all_ndsms, output)
+        # Note: Want real raster/no VRT as output
+        vrt_to_raster(vrt, output)
 
     grass.message(_(f"nDSM raster map <{output}> is created."))
 

--- a/r.ndsm.import/r.ndsm.import.py
+++ b/r.ndsm.import/r.ndsm.import.py
@@ -142,10 +142,7 @@ if path is None:
     grass.fatal("Unable to find the dem library directory.")
 sys.path.append(path)
 try:
-    from r_dem_import_lib import (
-        OPEN_DATA_AVAILABILITY,
-        import_local_data,
-    )
+    from r_dem_import_lib import OPEN_DATA_AVAILABILITY
     from r_dem_import_metadata_lib import get_download_urls_and_names
 except Exception as imp_err:
     grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
@@ -253,23 +250,21 @@ def main():
     local_ndsm_fs_list = []
     if local_data_dir_ndsm and local_data_dir_ndsm != "":
         local_ndsm_fs_list = os.listdir(local_data_dir_ndsm)
+        grass.fatal(_("Local nDSM data dir is not yet supported."))
 
     # local iDSM files
     local_idsm_fs_list = []
     if local_data_dir_idsm and local_data_dir_idsm != "":
-        grass.fatal(_("Local iDSM data dir for nDSM is not yet supported."))
         local_idsm_fs_list = os.listdir(local_data_dir_idsm)
 
     # local DSM files
     local_dsm_fs_list = []
     if local_data_dir_dsm and local_data_dir_dsm != "":
-        grass.fatal(_("Local DSM data dir for nDSM is not yet supported."))
         local_dsm_fs_list = os.listdir(local_data_dir_dsm)
 
     # local DTM files
     local_dtm_fs_list = []
     if local_data_dir_dtm and local_data_dir_dtm != "":
-        grass.fatal(_("Local DTM data dir for nDSM is not yet supported."))
         local_dtm_fs_list = os.listdir(local_data_dir_dtm)
 
     ndsm_list = []
@@ -282,19 +277,12 @@ def main():
         dsm_out = None
         # check if local data for federal state given
         imported_local_data = False
+        # TODO import local nDSM
         if fs in local_ndsm_fs_list:
             grass.message(_("Local nDSM import not yet supported!"))
-            imported_local_data = import_local_data(
-                aoi,
-                output,
-                local_data_dir_ndsm,
-                fs,
-                ndsm_list,
-                rm_rasters,
-                "raster",
-                nativ_res,
-            )
-        # TODO import nDSM via local iDSM/DSM and DTM
+        #     imported_local_data = import_local_data(
+        #         aoi_map, local_data_dir, fs, output_alkis_fs
+        #     )
         # elif fs in OPEN_DATA_AVAILABILITY["nDSM"]["NO_OPEN_DATA"]:
         #     grass.fatal(
         #         _(f"No local data for {fs} available. Is the path correct?")
@@ -539,7 +527,8 @@ def main():
             compute_ndsm(dtm_out, idsm_out, dsm_out, ndsm_out)
         ndsm_list.append(ndsm_out)
 
-    # create VRT
+    # Patch nDSMs of different federal states
+    # (keep as VRT. Federal states nDSMs itself are no VRTs)
     if len(ndsm_list) > 0:
         create_vrt(ndsm_list, output)
         # check result for completeness

--- a/r.ndsm.import/r.ndsm.import.py
+++ b/r.ndsm.import/r.ndsm.import.py
@@ -122,6 +122,7 @@ import grass.script as grass
 from grass.pygrass.utils import get_lib_path
 
 from grass_gis_helpers.cleanup import general_cleanup
+from grass_gis_helpers.data_import import import_local_raster_data
 from grass_gis_helpers.open_geodata_germany.download_data import (
     check_download_dir,
 )
@@ -141,7 +142,10 @@ if path is None:
     grass.fatal("Unable to find the dem library directory.")
 sys.path.append(path)
 try:
-    from r_dem_import_lib import OPEN_DATA_AVAILABILITY
+    from r_dem_import_lib import (
+        OPEN_DATA_AVAILABILITY,
+        import_local_data,
+    )
     from r_dem_import_metadata_lib import get_download_urls_and_names
 except Exception as imp_err:
     grass.fatal(f"r.dem.import library could not be imported: {imp_err}")
@@ -249,21 +253,23 @@ def main():
     local_ndsm_fs_list = []
     if local_data_dir_ndsm and local_data_dir_ndsm != "":
         local_ndsm_fs_list = os.listdir(local_data_dir_ndsm)
-        grass.fatal(_("Local nDSM data dir is not yet supported."))
 
     # local iDSM files
     local_idsm_fs_list = []
     if local_data_dir_idsm and local_data_dir_idsm != "":
+        grass.fatal(_("Local iDSM data dir for nDSM is not yet supported."))
         local_idsm_fs_list = os.listdir(local_data_dir_idsm)
 
     # local DSM files
     local_dsm_fs_list = []
     if local_data_dir_dsm and local_data_dir_dsm != "":
+        grass.fatal(_("Local DSM data dir for nDSM is not yet supported."))
         local_dsm_fs_list = os.listdir(local_data_dir_dsm)
 
     # local DTM files
     local_dtm_fs_list = []
     if local_data_dir_dtm and local_data_dir_dtm != "":
+        grass.fatal(_("Local DTM data dir for nDSM is not yet supported."))
         local_dtm_fs_list = os.listdir(local_data_dir_dtm)
 
     ndsm_list = []
@@ -276,12 +282,19 @@ def main():
         dsm_out = None
         # check if local data for federal state given
         imported_local_data = False
-        # TODO import local nDSM
         if fs in local_ndsm_fs_list:
             grass.message(_("Local nDSM import not yet supported!"))
-        #     imported_local_data = import_local_data(
-        #         aoi_map, local_data_dir, fs, output_alkis_fs
-        #     )
+            imported_local_data = import_local_data(
+                aoi,
+                output,
+                local_data_dir_ndsm,
+                fs,
+                ndsm_list,
+                rm_rasters,
+                "raster",
+                nativ_res,
+            )
+        # TODO import nDSM via local iDSM/DSM and DTM
         # elif fs in OPEN_DATA_AVAILABILITY["nDSM"]["NO_OPEN_DATA"]:
         #     grass.fatal(
         #         _(f"No local data for {fs} available. Is the path correct?")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-grass-gis-helpers>=3.0.0
+grass-gis-helpers>=3.1.0
 gdal
 remotezip
 wget


### PR DESCRIPTION
Requires
* Added functionalities: https://github.com/mundialis/grass-gis-helpers/pull/68
* Updated SH tindex https://github.com/mundialis/tile-indices/pull/88

Changes:
- clipping of xyz/laz files
   - created own function for this in lib: `xyz_laz_clip_region_aoi`
   - apply only for xyz/laz files, remove for tifs/r.import
- VRT creation
   - if raster created afterwards -> dont copy raster from other mapsets (new flag from grass gis helpers function)
   - for federal state specific datasets -> create real raster (not VRT)
   - if dataset for multiple federal states -> stay with VRT (of real rasters, see here above)
- federal state specific changes
   - for BB DTM: fixed delimiter
   - for SH: added metadaten functionality (missing)
   - for SH: removed own function for getting urls from tindex and used grass gis helpers function (after update of tindice column name, see PR above)