### PR TITLE
Add opendata flag option for local data dir

### DIFF
--- a/lib_dem/r_dem_import_lib.py
+++ b/lib_dem/r_dem_import_lib.py
@@ -331,6 +331,7 @@ def import_local_data(
     raster_type,
     native_res,
     ns_res,
+    opendata_flag,
     alignment_raster=None,
 ):
     """Import local DEM raster data.
@@ -348,6 +349,8 @@ def import_local_data(
         native_res (bool): Flag to keep native resolution of imported data
                            (True, if resolution kept)
         ns_res (float): Resolution to resample imported raster to
+        opendata_flag (boolean): Flag to indicate if data should be downloaded
+                                 from Open Data portal if local data dont match
         alignment_raster (str): If data should be resampled,
                                 raster to align imported data to
 
@@ -383,9 +386,14 @@ def import_local_data(
             ),
         )
 
-    if not imported_local_data and fs == "BW":
-        grass.fatal(_("Local data does not overlap with aoi."))
-    elif not imported_local_data:
+    if not imported_local_data and not opendata_flag:
+        grass.fatal(
+            _(
+                "Local data does not overlap with AOI. "
+                "Check local_data_dir or consider using o-flag.",
+            ),
+        )
+    elif not imported_local_data and opendata_flag:
         grass.message(
             _(
                 "Local data does not overlap with aoi. Data will be downloaded"

--- a/r.dsm.import/r.dsm.import.py
+++ b/r.dsm.import/r.dsm.import.py
@@ -92,9 +92,15 @@
 # % label: Use native data resolution
 # %end
 
+# %flag
+# % key: o
+# % description: For local data import: if no matching local data found, try to access via open data portal
+# %end
+
 # %rules
 # % requires_all: -k,download_dir
 # % excludes: -r,alignment_raster
+# % requires: -o, local_data_dir
 # %end
 
 import atexit
@@ -189,7 +195,15 @@ def main():
 
         # check if local data for federal state given
         imported_local_data = False
-        if fs in local_fs_list:
+        if fs not in local_fs_list and not flags["o"]:
+            grass.fatal(
+                _(
+                    f"Missing federal state folder '{fs}' "
+                    f"within local_data_dir: '{local_data_dir}'. "
+                    "Check local_data_dir or consider using o-flag.",
+                ),
+            )
+        elif fs in local_fs_list:
             grass.message(
                 _(
                     "NOTE: Local data DSM import currently "
@@ -208,6 +222,7 @@ def main():
                 "raster",
                 native_res,
                 ns_res,
+                flags["o"],
                 alignment_raster,
             )
             if imported_local_data:

--- a/r.dtm.import/r.dtm.import.py
+++ b/r.dtm.import/r.dtm.import.py
@@ -91,9 +91,15 @@
 # % label: Use native data resolution
 # %end
 
+# %flag
+# % key: o
+# % description: For local data import: if no matching local data found, try to access via open data portal
+# %end
+
 # %rules
 # % requires_all: -k,download_dir
 # % excludes: -r,alignment_raster
+# % requires: -o, local_data_dir
 # %end
 
 import atexit
@@ -187,7 +193,15 @@ def main():
 
         # check if local data for federal state given
         imported_local_data = False
-        if fs in local_fs_list:
+        if fs not in local_fs_list and not flags["o"]:
+            grass.fatal(
+                _(
+                    f"Missing federal state folder '{fs}' "
+                    f"within local_data_dir: '{local_data_dir}'. "
+                    "Check local_data_dir or consider using o-flag.",
+                ),
+            )
+        elif fs in local_fs_list:
             grass.message(
                 _(
                     "NOTE: Local data DTM import currently "
@@ -206,6 +220,7 @@ def main():
                 "xyz",
                 native_res,
                 ns_res,
+                flags["o"],
                 alignment_raster,
             )
             if imported_local_data:

--- a/r.ndsm.import/r.ndsm.import.py
+++ b/r.ndsm.import/r.ndsm.import.py
@@ -109,9 +109,15 @@
 # % label: Use native data resolution
 # %end
 
+# %flag
+# % key: o
+# % description: For local data import: if no matching local data found, try to access via open data portal
+# %end
+
 # %rules
 # % requires_all: -k,download_dir
 # % excludes: -r,alignment_raster
+# % requires: -o, local_data_dir_ndsm, local_data_dir_idsm, local_data_dir_dsm, local_data_dir_dtm
 # %end
 
 import atexit
@@ -287,7 +293,15 @@ def main():
         dsm_out = None
         # check if local data for federal state given
         imported_local_data = False
-        if fs in local_ndsm_fs_list:
+        if fs not in local_ndsm_fs_list and not flags["o"]:
+            grass.fatal(
+                _(
+                    f"Missing federal state folder '{fs}' "
+                    f"within local_data_dir_ndsm: '{local_data_dir_ndsm}'. "
+                    "Check local_data_dir_ndsm or consider using o-flag.",
+                ),
+            )
+        elif fs in local_ndsm_fs_list:
             grass.message(
                 _(
                     "NOTE: Local data nDSM import currently "
@@ -306,6 +320,7 @@ def main():
                 "raster",
                 native_res,
                 ns_res,
+                flags["o"],
                 alignment_raster,
             )
             # If local data import, was not succesfull,


### PR DESCRIPTION
For local data import:
If no matching local data found, currently data from open data portal are tried to download (except for BW).
This ist changed, such that by default the addon fails, if no matching data found from local data dir. With the -o flag however the old approach, trying the download from open data portal, is kept.